### PR TITLE
feat: add customs colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,3 @@
 @import 'tailwindcss';
+
+@import '../styles/index.css';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-   return <div className={'display-flex bg-red-400'}></div>
+   return <div className="bg-accent-500">Test</div>
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-   return <div className="bg-accent-500">Test</div>
+   return <div className="bg-[var(--color-accent-500)]">Test</div>
 }

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -1,0 +1,43 @@
+:root {
+    /* accent */
+    --color-accent-100: #73A5FF;
+    --color-accent-300: #4C8DFF;
+    --color-accent-500: #397DF6;
+    --color-accent-700: #2F68CC;
+    --color-accent-900: #234E99;
+
+    /* success */
+    --color-success-100: #80ffbf;
+    --color-success-300: #22e584;
+    --color-success-500: #14cc70;
+    --color-success-700: #0f9954;
+    --color-success-900: #0a6638;
+
+    /* danger */
+    --color-danger-100: #ff8099;
+    --color-danger-300: #f23d61;
+    --color-danger-500: #cc1439;
+    --color-danger-700: #990f2b;
+    --color-danger-900: #660a1d;
+
+    /* warning */
+    --color-warning-100: #ffd073;
+    --color-warning-300: #e5ac39;
+    --color-warning-500: #d99000;
+    --color-warning-700: #996600;
+    --color-warning-900: #664400;
+
+    /* dark */
+    --color-dark-100: #4C4C4C;
+    --color-dark-300: #333333;
+    --color-dark-500: #171717;
+    --color-dark-700: #0D0D0D;
+    --color-dark-900: #000000;
+
+    /* light */
+    --color-light-100: #FFFFFF;
+    --color-light-300: #F7FBFF;
+    --color-light-500: #EDF3FA;
+    --color-light-700: #D5DAE0;
+    --color-light-900: #8D9094;
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,1 @@
+@import './colors.css';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,64 @@
+/** @type {import('tailwindcss').Config} */
+export const content = [
+    './src/**/*.{js,ts,jsx,tsx}',
+];
+export const theme = {
+    extend: {
+        colors: {
+            // Accent colors
+            accent: {
+                100: 'var(--color-accent-100)',
+                300: 'var(--color-accent-300)',
+                500: 'var(--color-accent-500)',
+                700: 'var(--color-accent-700)',
+                900: 'var(--color-accent-900)',
+            },
+
+            // Success colors
+            success: {
+                100: 'var(--color-success-100)',
+                300: 'var(--color-success-300)',
+                500: 'var(--color-success-500)',
+                700: 'var(--color-success-700)',
+                900: 'var(--color-success-900)',
+            },
+
+            // Danger colors
+            danger: {
+                100: 'var(--color-danger-100)',
+                300: 'var(--color-danger-300)',
+                500: 'var(--color-danger-500)',
+                700: 'var(--color-danger-700)',
+                900: 'var(--color-danger-900)',
+            },
+
+            // Warning colors
+            warning: {
+                100: 'var(--color-warning-100)',
+                300: 'var(--color-warning-300)',
+                500: 'var(--color-warning-500)',
+                700: 'var(--color-warning-700)',
+                900: 'var(--color-warning-900)',
+            },
+
+            // Dark colors
+            dark: {
+                100: 'var(--color-dark-100)',
+                300: 'var(--color-dark-300)',
+                500: 'var(--color-dark-500)',
+                700: 'var(--color-dark-700)',
+                900: 'var(--color-dark-900)',
+            },
+
+            // Light colors
+            light: {
+                100: 'var(--color-light-100)',
+                300: 'var(--color-light-300)',
+                500: 'var(--color-light-500)',
+                700: 'var(--color-light-700)',
+                900: 'var(--color-light-900)',
+            }
+        },
+    },
+};
+export const plugins = [];


### PR DESCRIPTION
Добавил кастомные цвета. Но не работают кастомные цвета через tailwind когда прописываешь: <div className="bg-accent-500">Test</div>}. В нейронке спросил надо добавить tailwind.config.js, добавил ничего не поменялось. Если кастомные цвета прописывать просто через инлайн стили то работает: <div style={{ color: 'var(--color-accent-500)' }}>Text</div>. Посмотрите кто шарит в tailwind как пофиксить.
<img width="1280" height="750" alt="Pic3" src="https://github.com/user-attachments/assets/b4701aa9-822c-410c-b8a7-cfd6fb7ba97b" />

