### PR TITLE
feat: add typography component

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
       "build-storybook": "storybook build"
    },
    "dependencies": {
+      "clsx": "^2.1.1",
       "next": "15.5.2",
       "react": "19.1.0",
       "react-dom": "19.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       next:
         specifier: 15.5.2
         version: 15.5.2(@babel/core@7.28.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1443,6 +1446,10 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4469,6 +4476,8 @@ snapshots:
       string-width: 7.2.0
 
   client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:

--- a/src/shared/components/Typography/Typography.stories.tsx
+++ b/src/shared/components/Typography/Typography.stories.tsx
@@ -1,0 +1,44 @@
+import { Typography } from '@/shared/components/Typography/Typography'
+import { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { typographyVariants } from '@/shared/lib'
+
+const meta = {
+   argTypes: {
+      as: {
+         options: ['p', 'h1', 'h2', 'h3', 'h4', 'span', 'label', 'div'],
+      },
+      variant: {
+         control: { type: 'select' },
+         options: [...typographyVariants],
+      },
+   },
+   component: Typography,
+   parameters: {
+      layout: 'centered',
+   },
+   tags: ['autodocs'],
+   title: 'Components/Typography',
+} satisfies Meta<typeof Typography>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const H1: Story = {
+   args: {
+      children: 'Card content',
+      variant: 'h1',
+   },
+}
+
+export const AllVariants: Story = {
+   render: () => (
+      <div className="flex flex-col">
+         {typographyVariants.map(variant => (
+            <div key={variant} className="flex items-center gap-5">
+               <span className="text-m text-gray-500">{variant}:</span>
+               <Typography variant={variant}>Card content</Typography>
+            </div>
+         ))}
+      </div>
+   ),
+}

--- a/src/shared/components/Typography/Typography.tsx
+++ b/src/shared/components/Typography/Typography.tsx
@@ -1,5 +1,6 @@
 import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react'
 import { TypographyVariant } from '@/shared/lib'
+import { clsx } from 'clsx'
 
 export type TypographyProps<T extends ElementType = 'p'> = {
    as?: T
@@ -32,11 +33,9 @@ export const Typography = <T extends ElementType = 'p'>({
    ...rest
 }: TypographyProps<T>) => {
    const Component = as || 'p'
-   const baseClass = variantClasses[variant]
-   const mergedClass = className ? `${baseClass} ${className}` : baseClass
 
    return (
-      <Component className={mergedClass} {...rest}>
+      <Component className={clsx(variantClasses[variant], className)} {...rest}>
          {children}
       </Component>
    )

--- a/src/shared/components/Typography/Typography.tsx
+++ b/src/shared/components/Typography/Typography.tsx
@@ -1,29 +1,16 @@
-import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react'
+import { ComponentPropsWithRef, ElementType, ReactNode } from 'react'
 import { TypographyVariant } from '@/shared/lib'
 import { clsx } from 'clsx'
+import { resolveTypographyTag } from '@/shared/components/Typography/resolveTag'
+import { variantClasses } from '@/shared/components/Typography/variantClasses'
+import Link from 'next/link'
 
-export type TypographyProps<T extends ElementType = 'p'> = {
+export type TypographyProps<T extends ElementType> = {
    as?: T
    children?: ReactNode
    className?: string
    variant?: TypographyVariant
-} & ComponentPropsWithoutRef<T>
-
-const variantClasses: Record<TypographyVariant, string> = {
-   large: 'text-xxl font-semibold leading-l',
-   h1: 'text-xl font-bold leading-l',
-   h2: 'text-l font-bold leading-m',
-   h3: 'text-m font-semibold leading-m',
-   bodyRegular: 'text-m font-regular leading-m',
-   bodyBold: 'text-m font-bold leading-m',
-   captionRegular: 'text-s font-regular leading-m',
-   captionMedium: 'text-s font-medium leading-m',
-   captionBold: 'text-s font-bold leading-m',
-   smallRegular: 'text-xs font-regular  leading-s',
-   smallBold: 'text-xs font-semibold leading-s',
-   linkRegular: 'cursor-pointer text-s font-regular text-accent-500 underline leading-m',
-   linkSmall: 'cursor-pointer text-s font-regular text-accent-500 underline leading-s',
-}
+} & (T extends typeof Link ? ComponentPropsWithRef<typeof Link> : ComponentPropsWithRef<T>)
 
 export const Typography = <T extends ElementType = 'p'>({
    as,
@@ -32,10 +19,14 @@ export const Typography = <T extends ElementType = 'p'>({
    variant = 'bodyRegular',
    ...rest
 }: TypographyProps<T>) => {
-   const Component = as || 'p'
+   const Component = resolveTypographyTag(as, variant)
+   const mergedClass =
+      variant in variantClasses
+         ? clsx(variantClasses[variant as TypographyVariant], className)
+         : className
 
    return (
-      <Component className={clsx(variantClasses[variant], className)} {...rest}>
+      <Component className={mergedClass} {...rest}>
          {children}
       </Component>
    )

--- a/src/shared/components/Typography/Typography.tsx
+++ b/src/shared/components/Typography/Typography.tsx
@@ -1,0 +1,43 @@
+import { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react'
+import { TypographyVariant } from '@/shared/lib'
+
+export type TypographyProps<T extends ElementType = 'p'> = {
+   as?: T
+   children?: ReactNode
+   className?: string
+   variant?: TypographyVariant
+} & ComponentPropsWithoutRef<T>
+
+const variantClasses: Record<TypographyVariant, string> = {
+   large: 'text-xxl font-semibold leading-l',
+   h1: 'text-xl font-bold leading-l',
+   h2: 'text-l font-bold leading-m',
+   h3: 'text-m font-semibold leading-m',
+   bodyRegular: 'text-m font-regular leading-m',
+   bodyBold: 'text-m font-bold leading-m',
+   captionRegular: 'text-s font-regular leading-m',
+   captionMedium: 'text-s font-medium leading-m',
+   captionBold: 'text-s font-bold leading-m',
+   smallRegular: 'text-xs font-regular  leading-s',
+   smallBold: 'text-xs font-semibold leading-s',
+   linkRegular: 'cursor-pointer text-s font-regular text-accent-500 underline leading-m',
+   linkSmall: 'cursor-pointer text-s font-regular text-accent-500 underline leading-s',
+}
+
+export const Typography = <T extends ElementType = 'p'>({
+   as,
+   children,
+   className,
+   variant = 'bodyRegular',
+   ...rest
+}: TypographyProps<T>) => {
+   const Component = as || 'p'
+   const baseClass = variantClasses[variant]
+   const mergedClass = className ? `${baseClass} ${className}` : baseClass
+
+   return (
+      <Component className={mergedClass} {...rest}>
+         {children}
+      </Component>
+   )
+}

--- a/src/shared/components/Typography/index.ts
+++ b/src/shared/components/Typography/index.ts
@@ -1,0 +1,1 @@
+export { Typography } from './Typography'

--- a/src/shared/components/Typography/index.ts
+++ b/src/shared/components/Typography/index.ts
@@ -1,1 +1,3 @@
 export { Typography } from './Typography'
+export { variantClasses } from './variantClasses'
+export { resolveTypographyTag } from './resolveTag'

--- a/src/shared/components/Typography/resolveTag.ts
+++ b/src/shared/components/Typography/resolveTag.ts
@@ -1,0 +1,33 @@
+import { ElementType } from 'react'
+import { TypographyVariant } from '@/shared/lib'
+import Link from 'next/link'
+
+export function resolveTypographyTag(
+   as: ElementType,
+   variant: TypographyVariant = 'bodyRegular'
+): ElementType {
+   switch (variant) {
+      case 'h1':
+      case 'h2':
+      case 'h3':
+         return as ?? variant
+      case 'linkRegular':
+      case 'linkSmall':
+         return as ?? Link
+      case 'large':
+      case 'bodyRegular':
+      case 'bodyBold':
+      case 'captionRegular':
+      case 'captionMedium':
+      case 'captionBold':
+      case 'smallRegular':
+      case 'smallBold':
+         return as ?? 'p'
+      default:
+         return exhaustiveCheck(variant)
+   }
+}
+
+function exhaustiveCheck(value: never): never {
+   return value
+}

--- a/src/shared/components/Typography/variantClasses.ts
+++ b/src/shared/components/Typography/variantClasses.ts
@@ -1,0 +1,17 @@
+import { TypographyVariant } from '@/shared/lib'
+
+export const variantClasses: Record<TypographyVariant, string> = {
+   large: 'text-xxl font-semibold leading-l',
+   h1: 'text-xl font-bold leading-l',
+   h2: 'text-l font-bold leading-m',
+   h3: 'text-m font-semibold leading-m',
+   bodyRegular: 'text-m font-regular leading-m',
+   bodyBold: 'text-m font-bold leading-m',
+   captionRegular: 'text-s font-regular leading-m',
+   captionMedium: 'text-s font-medium leading-m',
+   captionBold: 'text-s font-bold leading-m',
+   smallRegular: 'text-xs font-regular  leading-s',
+   smallBold: 'text-xs font-semibold leading-s',
+   linkRegular: 'cursor-pointer text-s font-regular text-accent-500 underline leading-m',
+   linkSmall: 'cursor-pointer text-s font-regular text-accent-500 underline leading-s',
+}

--- a/src/shared/lib/index.ts
+++ b/src/shared/lib/index.ts
@@ -1,0 +1,2 @@
+export { typographyVariants } from './typographyVariants'
+export type { TypographyVariant } from './typographyVariants'

--- a/src/shared/lib/typographyVariants.ts
+++ b/src/shared/lib/typographyVariants.ts
@@ -1,0 +1,17 @@
+export const typographyVariants = [
+   'large',
+   'h1',
+   'h2',
+   'h3',
+   'bodyRegular',
+   'bodyBold',
+   'captionRegular',
+   'captionMedium',
+   'captionBold',
+   'smallRegular',
+   'smallBold',
+   'linkRegular',
+   'linkSmall',
+] as const
+
+export type TypographyVariant = (typeof typographyVariants)[number]


### PR DESCRIPTION
Добавлен компонент Typography с поддержкой variant/as

Все варианты в storybook: 
<img width="1257" height="595" alt="image" src="https://github.com/user-attachments/assets/14f70dcf-7a15-46bd-b1f5-4b9d6d1dd484" />
