### PR TITLE
KAN-56 feat: add PageContainer component

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,14 @@
+import { PageContainer } from '@/shared/components/PageContainer'
 import { RadioGroup, RadioItem } from '@/shared/components/Radio-group'
 
 export default function Home() {
    return (
-      <RadioGroup>
-         <RadioItem value="1" label="Первый вариант" />
-         <RadioItem value="2" label="Второй вариант" />
-         <RadioItem value="3" label="Третий вариант" />
-      </RadioGroup>
+      <PageContainer className="flex flex-col items-center">
+         <RadioGroup>
+            <RadioItem value="1" label="Первый вариант" />
+            <RadioItem value="2" label="Второй вариант" />
+            <RadioItem value="3" label="Третий вариант" />
+         </RadioGroup>
+      </PageContainer>
    )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import { RadioGroup, RadioItem } from '@/shared/components/Radio-group'
 
 export default function Home() {
    return (
-      <PageContainer className="flex flex-col items-center">
+      <PageContainer>
          <RadioGroup>
             <RadioItem value="1" label="Первый вариант" />
             <RadioItem value="2" label="Второй вариант" />

--- a/src/shared/components/PageContainer/PageContainer.tsx
+++ b/src/shared/components/PageContainer/PageContainer.tsx
@@ -1,13 +1,13 @@
 'use client'
 import { type ComponentPropsWithRef } from 'react'
-import { clsx } from 'clsx'
+import { cn } from '@/shared/lib'
 
 type Props = ComponentPropsWithRef<'main'> & {
    className?: string
 }
 
 export function PageContainer({ className, ...rest }: Props) {
-   const classNames = clsx('mx-auto w-full', 'max-w-[1280px] py-6 px-[60px]', className)
-
-   return <main className={classNames} {...rest} />
+   return (
+      <main className={cn('mx-auto w-full max-w-[1280px] px-[60px] py-6', className)} {...rest} />
+   )
 }

--- a/src/shared/components/PageContainer/PageContainer.tsx
+++ b/src/shared/components/PageContainer/PageContainer.tsx
@@ -1,0 +1,13 @@
+'use client'
+import { type ComponentPropsWithRef } from 'react'
+import { clsx } from 'clsx'
+
+type Props = ComponentPropsWithRef<'main'> & {
+   className?: string
+}
+
+export function PageContainer({ className, ...rest }: Props) {
+   const classNames = clsx('mx-auto w-full', 'max-w-[1280px] py-6 px-[60px]', className)
+
+   return <main className={classNames} {...rest} />
+}

--- a/src/shared/components/PageContainer/PageContainer.tsx
+++ b/src/shared/components/PageContainer/PageContainer.tsx
@@ -1,4 +1,3 @@
-'use client'
 import { type ComponentPropsWithRef } from 'react'
 import { cn } from '@/shared/lib'
 

--- a/src/shared/components/PageContainer/PageContainer.tsx
+++ b/src/shared/components/PageContainer/PageContainer.tsx
@@ -7,6 +7,12 @@ type Props = ComponentPropsWithRef<'main'> & {
 
 export function PageContainer({ className, ...rest }: Props) {
    return (
-      <main className={cn('mx-auto w-full max-w-[1280px] px-[60px] py-6', className)} {...rest} />
+      <main
+         className={cn(
+            'mx-auto flex w-full max-w-[1280px] flex-col items-center px-[60px] pt-6',
+            className
+         )}
+         {...rest}
+      />
    )
 }

--- a/src/shared/components/PageContainer/index.ts
+++ b/src/shared/components/PageContainer/index.ts
@@ -1,0 +1,1 @@
+export * from './PageContainer'


### PR DESCRIPTION
Добавлен контейнер для страницы.
Задана ширина максимальная по макету, отступы и выравнивание контейнера по центру сраницы.

Стили добавить можно через className.

Контейнер оборачивает содержимое в Page.tsx
`<PageContainer className="flex flex-col items-center">
         <RadioGroup>
            <RadioItem value="1" label="Первый вариант" />
            <RadioItem value="2" label="Второй вариант" />
            <RadioItem value="3" label="Третий вариант" />
         </RadioGroup>
      </PageContainer>`

<img width="1280" height="1024" alt="container" src="https://github.com/user-attachments/assets/5b75c8e8-2681-473e-b768-b57c9cab1286" />
