### PR TITLE
KAN-16 refactor: add items and children props in Sidebar

### DIFF
--- a/src/widgets/Sidebar/Sidebar.stories.tsx
+++ b/src/widgets/Sidebar/Sidebar.stories.tsx
@@ -7,7 +7,6 @@ import {
    HomeOutlineIcon,
    LogoutIcon,
 } from '@/shared/icons'
-import { sidebarData } from '@/widgets/Sidebar/sidebarData'
 import { action } from 'storybook/actions'
 
 const meta = {
@@ -21,17 +20,7 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
-   args: {
-      children: (
-         <>
-            {sidebarData.map(item => (
-               <SidebarItem key={item.id} {...item} />
-            ))}
-         </>
-      ),
-   },
-}
+export const Default: Story = {}
 
 export const WithDisabledItem: Story = {
    args: {

--- a/src/widgets/Sidebar/Sidebar.tsx
+++ b/src/widgets/Sidebar/Sidebar.tsx
@@ -4,14 +4,20 @@ import React, { ComponentPropsWithRef } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/shared/lib'
-import { SidebarItemType } from '@/widgets/Sidebar/sidebarData'
+import { sidebarData, SidebarItemType } from '@/widgets/Sidebar/sidebarData'
 
-export type Props = SidebarItemType & ComponentPropsWithRef<'li'>
+export type SidebarProps = {
+   items?: SidebarItemType[]
+} & ComponentPropsWithRef<'nav'>
 
-export const Sidebar = ({ children, className, ...rest }: ComponentPropsWithRef<'nav'>) => {
+export type SidebarItemProps = SidebarItemType & ComponentPropsWithRef<'li'>
+
+export const Sidebar = ({ items = sidebarData, children, className, ...rest }: SidebarProps) => {
    return (
-      <nav {...rest} className={cn('fixed top-[72px] min-w-[220px] pl-15', className)}>
-         <ul className={cn('border-dark-300 flex flex-col border-r')}>{children}</ul>
+      <nav {...rest} className={cn('fixed top-[72px] min-w-[220px] pl-[60px]', className)}>
+         <ul className={cn('border-dark-300 flex flex-col border-r')}>
+            {children ? children : items.map(item => <SidebarItem key={item.id} {...item} />)}
+         </ul>
       </nav>
    )
 }
@@ -25,7 +31,7 @@ export const SidebarItem = ({
    onClick,
    className,
    ...rest
-}: Props) => {
+}: SidebarItemProps) => {
    const currentPath = usePathname()
    const IconToRender = currentPath === path && ActiveIcon ? ActiveIcon : Icon
 


### PR DESCRIPTION
1. Добавлено свойство items со значением по умолчанию, теперь Sidebar сам рендерит список из sidebarData
Использование: `<Sidebar />`

2. Другое меню через items
Использование: `<Sidebar items={otherMenu} />`

3. Поддержка children также осталась