### PR TITLE
KAN-72 feat: disable forgot-password button until email is entered

### DIFF
--- a/src/features/auth/forms/ForgotPasswordForm/ForgotPassword.stories.tsx
+++ b/src/features/auth/forms/ForgotPasswordForm/ForgotPassword.stories.tsx
@@ -1,10 +1,19 @@
+import { Provider } from 'react-redux'
 import { ForgotPasswordForm } from './ForgotPasswordForm'
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { store } from '@/shared/store'
 
 const meta = {
    component: ForgotPasswordForm,
    tags: ['autodocs'],
    title: 'Forms/ForgotPasswordForm',
+   decorators: [
+      Story => (
+         <Provider store={store}>
+            <Story />
+         </Provider>
+      ),
+   ],
 } satisfies Meta<typeof ForgotPasswordForm>
 
 export default meta

--- a/src/features/auth/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/features/auth/forms/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -23,19 +23,22 @@ type Props = {
 }
 
 export const ForgotPasswordForm = ({ onSubmitAction, errorsFromApi }: Props) => {
-   const [recaptchaReady, setRecaptchaReady] = useState(false)
+   const [recaptchaReady, setRecaptchaReady] = useState(true)
 
    const {
       control,
       formState: { errors },
       handleSubmit,
       setError,
+      watch,
    } = useForm<FormTypes>({
       defaultValues: {
          email: '',
       },
       resolver: zodResolver(schema),
    })
+
+   const emailValue = watch('email')
 
    useEffect(() => {
       errorsFromApi?.forEach(error => {
@@ -64,7 +67,7 @@ export const ForgotPasswordForm = ({ onSubmitAction, errorsFromApi }: Props) => 
             <Typography variant={'captionRegular'} className={'text-light-900 mb-[17px]'}>
                Enter your email address and we will send you further instructions
             </Typography>
-            <Button fullWidth className={'mb-6'} disabled={!recaptchaReady}>
+            <Button fullWidth className={'mb-6'} disabled={!recaptchaReady || !emailValue}>
                Send Link
             </Button>
             <Button fullWidth asChild variant="textButton" className={'mb-6'}>


### PR DESCRIPTION
Disabled состояние кнопки Send Link в случае, если reCAPTCHA не пройдена (было реализовано ранее) и/или инпут не заполнен (добавлено в этом коммите)