### PR TITLE
YAY-25 feat: add posts for Main

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,24 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
    /* config options here */
+
+   //to download images from other hosts
+   images: {
+      remotePatterns: [
+         {
+            protocol: 'https',
+            hostname: 'images.unsplash.com',
+         },
+         {
+            protocol: 'https',
+            hostname: 'mypixelgram.ru',
+         },
+         {
+            protocol: 'https',
+            hostname: 'randomuser.me',
+         },
+      ],
+   },
 }
 
 export default nextConfig

--- a/src/app/(private)/profile/page.tsx
+++ b/src/app/(private)/profile/page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { PostCreator } from '@/features/post-creator/PostCreator'
 import { PageContainer } from '@/shared/components/PageContainer'
 import { useSearchParams, useRouter } from 'next/navigation'
@@ -6,8 +8,8 @@ type Props = {
    params: { id: string }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function ProfilePage({ params }: Props) {
-
    const router = useRouter()
    const searchParams = useSearchParams()
    const action = searchParams.get('action')
@@ -18,11 +20,7 @@ export default function ProfilePage({ params }: Props) {
 
    return (
       <PageContainer>
-         
-         {action === 'create' && (
-            <PostCreator onClose={handleClosePostCreator} />
-         )}
-
+         {action === 'create' && <PostCreator onClose={handleClosePostCreator} />}
          ProfilePage
          <p>
             {' '}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,145 +1,24 @@
+import { CardPost, PostProps } from '@/entities/posts/ui/CardPost'
 import ServerPageContainer from '@/shared/components/PageContainer/ServerPageContainer'
-import Image from 'next/image'
 
 export const revalidateTime = 60
 
 //const images = ['./public/404.jpg', './public/logo-light.png', './public/logo-dark.png']
-
-type Post = {
-   postId: string
-   description: string
-   location: string
-   file: { url: string }
-   createdAt: string
-   user: {
-      userId: string
-      userName: string
-      avatar: string | null
-   }
-}
 
 export default async function Home() {
    const res = await fetch('https://mypixelgram.ru/api/v1/public/posts/last-posts', {
       next: { revalidate: revalidateTime },
    })
 
-   const data: { posts: Post[] } = await res.json()
+   const data: { posts: PostProps[] } = await res.json()
 
    return (
       <ServerPageContainer>
          <div className="flex flex-wrap gap-4">
             {data.posts.map(post => {
-               const createdAt = new Date(post.createdAt).toLocaleString('ru-RU', {
-                  day: '2-digit',
-                  month: 'short',
-                  year: 'numeric',
-                  hour: '2-digit',
-                  minute: '2-digit',
-               })
-
-               return (
-                  <div
-                     key={post.postId}
-                     className="bg-dark-500 border-dark-300 h-[391px] w-[234px] overflow-hidden border"
-                  >
-                     {/* Пост-картинка */}
-                     {post.file?.url && (
-                        <div className="relative h-[240px] w-[234px]">
-                           <Image
-                              src={post.file.url}
-                              alt="post"
-                              className="object-cover"
-                              sizes="234px"
-                              fill
-                           />
-                        </div>
-                        //<Slider images={images} className={'h-[240px] w-[234px]'} />
-                     )}
-
-                     {/* Информация о пользователе */}
-                     <div className="flex items-center gap-2 p-2 text-sm text-white">
-                        {post.user.avatar && (
-                           <Image
-                              src={post.user.avatar}
-                              alt={post.user.userName}
-                              width={32}
-                              height={32}
-                              className="rounded-full object-cover"
-                           />
-                        )}
-                        <div className="flex flex-col">
-                           <span className="font-medium">{post.user.userName}</span>
-                           <span className="text-xs text-gray-400">{createdAt}</span>
-                        </div>
-                     </div>
-
-                     {/* Описание поста */}
-                     <div className="p-2 text-sm text-gray-400">
-                        <p>{post.description}</p>
-                        {post.location && <p className="text-xs text-gray-500">{post.location}</p>}
-                     </div>
-                  </div>
-               )
+               return <CardPost key={post.postId} {...post} />
             })}
          </div>
       </ServerPageContainer>
    )
 }
-
-/* import ServerPageContainer from "@/shared/components/PageContainer/ServerPageContainer"
-
-type CardProps = {
-   children?: React.ReactNode
-}
-
-
-
-export const revalidate = 60
-
-export default async function Home() {
-  const res = await fetch('https://mypixelgram.ru/api/v1/public/posts/last-posts', {
-    next: { revalidate: 60 },
-  })
-  const data = await res.json()
-
-  return (
-    <ServerPageContainer>
-      <div className="bg-dark-500 border-dark-300 mb-[36px] h-[72px] w-[972px] border" />
-      <div className="flex flex-wrap gap-4">
-        {data.posts.map((post: any) => (
-          <Card key={post.postId} post={post} />
-        ))}
-      </div>
-    </ServerPageContainer>
-  )
-}
-
-const Card = ({ children }: CardProps) => {
-   return <div className="bg-dark-500 border-dark-300 h-[391px] w-[234px] border">{children}</div>
-} */
-
-/* import { PageContainer } from '@/shared/components/PageContainer'
-
-const arr = ['1', '2', '3', '4']
-
-type CardProps = {
-   children?: React.ReactNode
-}
-
-export default function Home() {
-   return (
-      <PageContainer>
-         <div className="bg-dark-500 border-dark-300 mb-[36px] h-[72px] w-[972px] border"></div>
-         <div className="flex flex-row gap-4">
-            {arr.map((el, index) => (
-               <Card key={index}>{el}</Card>
-            ))}
-         </div>
-      </PageContainer>
-   )
-}
-
-const Card = ({ children }: CardProps) => {
-   return <div className="bg-dark-500 border-dark-300 h-[391px] w-[234px] border">{children}</div>
-}
- */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,25 +1,34 @@
-import { CardPost, PostProps } from '@/entities/posts/ui/CardPost'
+import { CardPost } from '@/entities/posts/ui/CardPost'
 import ServerPageContainer from '@/shared/components/PageContainer/ServerPageContainer'
 import { apiMap } from '@/shared/constants'
+import { postsSchema } from '@/shared/schema/postsSchema'
 
-const revalidateTime = 60
+export const revalidateTime = 60
 
 export default async function Home() {
-   const res = await fetch(apiMap.lastPosts, {
-      next: { revalidate: revalidateTime },
-   })
+   try {
+      const res = await fetch(apiMap.lastPosts)
+      const json = await res.json()
+      const data = postsSchema.parse(json)
 
-   const data: { posts: PostProps[] } = await res.json()
+      return (
+         <ServerPageContainer>
+            <div className="bg-dark-500 border-dark-300 mb-[36px] h-[72px] w-[972px] border"></div>
 
-   return (
-      <ServerPageContainer>
-         <div className="bg-dark-500 border-dark-300 mb-[36px] h-[72px] w-[972px] border"></div>
-
-         <div className="flex max-w-[972px] flex-wrap gap-3">
-            {data.posts.map(post => {
-               return <CardPost key={post.postId} {...post} />
-            })}
-         </div>
-      </ServerPageContainer>
-   )
+            <div className="flex max-w-[972px] flex-wrap gap-3">
+               {data.posts.map(post => {
+                  return <CardPost key={post.postId} {...post} />
+               })}
+            </div>
+         </ServerPageContainer>
+      )
+   } catch {
+      return (
+         <ServerPageContainer>
+            <div className="bg-dark-500 border-dark-300 border p-4">
+               Failed to load posts. Please try again later.
+            </div>
+         </ServerPageContainer>
+      )
+   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,7 +16,7 @@ export default async function Home() {
       <ServerPageContainer>
          <div className="bg-dark-500 border-dark-300 mb-[36px] h-[72px] w-[972px] border"></div>
 
-         <div className="flex flex-wrap gap-4">
+         <div className="flex max-w-[972px] flex-wrap gap-3">
             {data.posts.map(post => {
                return <CardPost key={post.postId} {...post} />
             })}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,124 @@
-import { PageContainer } from '@/shared/components/PageContainer'
+import ServerPageContainer from '@/shared/components/PageContainer/ServerPageContainer'
+import Image from 'next/image'
+
+export const revalidateTime = 60
+
+//const images = ['./public/404.jpg', './public/logo-light.png', './public/logo-dark.png']
+
+type Post = {
+   postId: string
+   description: string
+   location: string
+   file: { url: string }
+   createdAt: string
+   user: {
+      userId: string
+      userName: string
+      avatar: string | null
+   }
+}
+
+export default async function Home() {
+   const res = await fetch('https://mypixelgram.ru/api/v1/public/posts/last-posts', {
+      next: { revalidate: revalidateTime },
+   })
+
+   const data: { posts: Post[] } = await res.json()
+
+   return (
+      <ServerPageContainer>
+         <div className="flex flex-wrap gap-4">
+            {data.posts.map(post => {
+               const createdAt = new Date(post.createdAt).toLocaleString('ru-RU', {
+                  day: '2-digit',
+                  month: 'short',
+                  year: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+               })
+
+               return (
+                  <div
+                     key={post.postId}
+                     className="bg-dark-500 border-dark-300 h-[391px] w-[234px] overflow-hidden border"
+                  >
+                     {/* Пост-картинка */}
+                     {post.file?.url && (
+                        <div className="relative h-[240px] w-[234px]">
+                           <Image
+                              src={post.file.url}
+                              alt="post"
+                              className="object-cover"
+                              sizes="234px"
+                              fill
+                           />
+                        </div>
+                        //<Slider images={images} className={'h-[240px] w-[234px]'} />
+                     )}
+
+                     {/* Информация о пользователе */}
+                     <div className="flex items-center gap-2 p-2 text-sm text-white">
+                        {post.user.avatar && (
+                           <Image
+                              src={post.user.avatar}
+                              alt={post.user.userName}
+                              width={32}
+                              height={32}
+                              className="rounded-full object-cover"
+                           />
+                        )}
+                        <div className="flex flex-col">
+                           <span className="font-medium">{post.user.userName}</span>
+                           <span className="text-xs text-gray-400">{createdAt}</span>
+                        </div>
+                     </div>
+
+                     {/* Описание поста */}
+                     <div className="p-2 text-sm text-gray-400">
+                        <p>{post.description}</p>
+                        {post.location && <p className="text-xs text-gray-500">{post.location}</p>}
+                     </div>
+                  </div>
+               )
+            })}
+         </div>
+      </ServerPageContainer>
+   )
+}
+
+/* import ServerPageContainer from "@/shared/components/PageContainer/ServerPageContainer"
+
+type CardProps = {
+   children?: React.ReactNode
+}
+
+
+
+export const revalidate = 60
+
+export default async function Home() {
+  const res = await fetch('https://mypixelgram.ru/api/v1/public/posts/last-posts', {
+    next: { revalidate: 60 },
+  })
+  const data = await res.json()
+
+  return (
+    <ServerPageContainer>
+      <div className="bg-dark-500 border-dark-300 mb-[36px] h-[72px] w-[972px] border" />
+      <div className="flex flex-wrap gap-4">
+        {data.posts.map((post: any) => (
+          <Card key={post.postId} post={post} />
+        ))}
+      </div>
+    </ServerPageContainer>
+  )
+}
+
+const Card = ({ children }: CardProps) => {
+   return <div className="bg-dark-500 border-dark-300 h-[391px] w-[234px] border">{children}</div>
+} */
+
+/* import { PageContainer } from '@/shared/components/PageContainer'
 
 const arr = ['1', '2', '3', '4']
 
@@ -22,3 +142,4 @@ export default function Home() {
 const Card = ({ children }: CardProps) => {
    return <div className="bg-dark-500 border-dark-300 h-[391px] w-[234px] border">{children}</div>
 }
+ */

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import { CardPost, PostProps } from '@/entities/posts/ui/CardPost'
 import ServerPageContainer from '@/shared/components/PageContainer/ServerPageContainer'
 import { apiMap } from '@/shared/constants'
 
-export const revalidateTime = 60
+const revalidateTime = 60
 
 export default async function Home() {
    const res = await fetch(apiMap.lastPosts, {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { postsSchema } from '@/shared/schema/postsSchema'
 
 export const revalidateTime = 60
 
-export default async function Home() {
+export default async function HomePage() {
    try {
       const res = await fetch(apiMap.lastPosts)
       const json = await res.json()

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,6 @@ import ServerPageContainer from '@/shared/components/PageContainer/ServerPageCon
 
 export const revalidateTime = 60
 
-//const images = ['./public/404.jpg', './public/logo-light.png', './public/logo-dark.png']
-
 export default async function Home() {
    const res = await fetch('https://mypixelgram.ru/api/v1/public/posts/last-posts', {
       next: { revalidate: revalidateTime },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,8 @@ export default async function Home() {
 
    return (
       <ServerPageContainer>
+         <div className="bg-dark-500 border-dark-300 mb-[36px] h-[72px] w-[972px] border"></div>
+
          <div className="flex flex-wrap gap-4">
             {data.posts.map(post => {
                return <CardPost key={post.postId} {...post} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,1 +1,24 @@
-export default function Home() {}
+import { PageContainer } from '@/shared/components/PageContainer'
+
+const arr = ['1', '2', '3', '4']
+
+type CardProps = {
+   children?: React.ReactNode
+}
+
+export default function Home() {
+   return (
+      <PageContainer>
+         <div className="bg-dark-500 border-dark-300 mb-[36px] h-[72px] w-[972px] border"></div>
+         <div className="flex flex-row gap-4">
+            {arr.map((el, index) => (
+               <Card key={index}>{el}</Card>
+            ))}
+         </div>
+      </PageContainer>
+   )
+}
+
+const Card = ({ children }: CardProps) => {
+   return <div className="bg-dark-500 border-dark-300 h-[391px] w-[234px] border">{children}</div>
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,15 @@
 import { CardPost } from '@/entities/posts/ui/CardPost'
 import ServerPageContainer from '@/shared/components/PageContainer/ServerPageContainer'
 import { apiMap } from '@/shared/constants'
-import { postsSchema } from '@/shared/schema/postsSchema'
+import { lastPostsSchema } from '@/shared/schema'
 
-export const revalidateTime = 60
+export const revalidate = 60
 
 export default async function HomePage() {
    try {
       const res = await fetch(apiMap.lastPosts)
       const json = await res.json()
-      const data = postsSchema.parse(json)
+      const data = lastPostsSchema.parse(json)
 
       return (
          <ServerPageContainer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
 import { CardPost, PostProps } from '@/entities/posts/ui/CardPost'
 import ServerPageContainer from '@/shared/components/PageContainer/ServerPageContainer'
+import { apiMap } from '@/shared/constants'
 
 export const revalidateTime = 60
 
 export default async function Home() {
-   const res = await fetch('https://mypixelgram.ru/api/v1/public/posts/last-posts', {
+   const res = await fetch(apiMap.lastPosts, {
       next: { revalidate: revalidateTime },
    })
 

--- a/src/entities/posts/ui/CardPost/CardPost.stories.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.stories.tsx
@@ -1,4 +1,5 @@
-import { CardPost, PostProps } from '@/entities/posts/ui/CardPost'
+import { CardPost } from '@/entities/posts/ui/CardPost'
+import { PostProps } from '@/shared/schema/postsSchema'
 import { Meta, StoryObj } from '@storybook/nextjs-vite'
 
 const samplePost: PostProps = {

--- a/src/entities/posts/ui/CardPost/CardPost.stories.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.stories.tsx
@@ -1,0 +1,33 @@
+import { CardPost, PostProps } from '@/entities/posts/ui/CardPost'
+import { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+const samplePost: PostProps = {
+   postId: '1',
+   description:
+      'Second long hardcoded post. This text is intentionally verbose and extensive to demonstrate how a description in a social media post can contain much more detail, reflections, and personal impressions about the visited location, weather, events that happened during the This text is intentionally verbose and extensive to demonstrate how a description',
+   location: 'Minsk',
+   file: { url: './public/404.jpg' },
+   createdAt: new Date().toISOString(),
+   user: {
+      userId: '123',
+      userName: 'John Doe',
+      avatar: null,
+   },
+}
+
+const meta = {
+   title: 'UI/CardPost',
+   component: CardPost,
+   parameters: {
+      layout: 'centered',
+   },
+} satisfies Meta<typeof CardPost>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+   args: {
+      ...samplePost,
+   },
+}

--- a/src/entities/posts/ui/CardPost/CardPost.stories.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.stories.tsx
@@ -1,8 +1,8 @@
 import { CardPost } from '@/entities/posts/ui/CardPost'
-import { PostProps } from '@/shared/schema/postsSchema'
+import { LastPostProps } from '@/shared/schema'
 import { Meta, StoryObj } from '@storybook/nextjs-vite'
 
-const samplePost: PostProps = {
+const samplePost: LastPostProps = {
    postId: '1',
    description:
       'Second long hardcoded post. This text is intentionally verbose and extensive to demonstrate how a description in a social media post can contain much more detail, reflections, and personal impressions about the visited location, weather, events that happened during the This text is intentionally verbose and extensive to demonstrate how a description',

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -8,15 +8,17 @@ import { UserBlock } from './UserBlock'
 import { DescriptionBlock } from './DescriptionBlock'
 
 export const CardPost = ({ description, file, createdAt, user }: LastPostProps) => {
-   const [relativeTime, setRelativeTime] = useState(
-      formatDistanceToNow(new Date(createdAt), { addSuffix: true })
-   )
+   //for relative time, update every 60 sec
+   const [relativeTime, setRelativeTime] = useState('')
    const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
    useEffect(() => {
+      setRelativeTime(formatDistanceToNow(new Date(createdAt), { addSuffix: true }))
+
       const interval = setInterval(() => {
          setRelativeTime(formatDistanceToNow(new Date(createdAt), { addSuffix: true }))
       }, 60_000)
+
       return () => clearInterval(interval)
    }, [createdAt])
 

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@/shared/components/Card'
+import { Slider } from '@/shared/components/Slider'
 import Image from 'next/image'
 
 export type PostProps = {
@@ -14,6 +15,8 @@ export type PostProps = {
    }
 }
 
+//const images = ['./public/404.jpg', './public/logo-light.png', './public/logo-dark.png']
+
 export const CardPost = ({ description, location, file, createdAt, user }: PostProps) => {
    const createdAtPost = new Date(createdAt).toLocaleString('ru-RU', {
       day: '2-digit',
@@ -23,13 +26,15 @@ export const CardPost = ({ description, location, file, createdAt, user }: PostP
       minute: '2-digit',
    })
 
+   const images = [file.url]
+
    return (
       <Card className="bg-dark-500 h-[391px] w-[234px] overflow-hidden">
          {file?.url && (
-            <div className="relative h-[240px] w-[234px]">
-               <Image src={file.url} alt="post" className="object-cover" sizes="234px" fill />
-            </div>
-            //<Slider images={images} className={'h-[240px] w-[234px]'} />
+            //   <div className="relative h-[240px] w-[234px]">
+            //       <Image src={file.url} alt="post" className="object-cover" sizes="234px" fill />
+            //    </div>
+            <Slider images={images} className={'h-[240px] w-[234px]'} />
          )}
 
          {/* Информация о пользователе */}

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -1,8 +1,13 @@
+'use client'
+
 import { Card } from '@/shared/components/Card'
 import { Slider } from '@/shared/components/Slider'
-import { PostOutlineIcon } from '@/shared/icons'
-import Image from 'next/image'
 import { Typography } from '@/shared/components/Typography'
+import { PostOutlineIcon } from '@/shared/icons'
+import { cn } from '@/shared/lib'
+import clsx from 'clsx'
+import Image from 'next/image'
+import { useState } from 'react'
 
 export type PostProps = {
    postId: string
@@ -28,46 +33,102 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
       minute: '2-digit',
    })
 
-   const images = [file.url, file.url, file.url]
+   const [expanded, setExpanded] = useState(false)
 
+   if (!description) description = ''
+
+   // базовые лимиты
+   const SHORT_LIMIT = 90
+   const EXTENDED_LIMIT = 240
+
+   const shouldTruncate = description.length > SHORT_LIMIT
+   const visibleText = expanded
+      ? description.slice(0, EXTENDED_LIMIT)
+      : description.slice(0, SHORT_LIMIT)
+
+   const showHideButton = shouldTruncate && description.length > SHORT_LIMIT
+
+   const images = [file.url, file.url, file.url]
+   //h-[391px]
    return (
       <Card withBaseStyles={false} className="h-[391px] w-[234px] overflow-hidden">
-         {file?.url && (
-            //   <div className="relative h-[240px] w-[234px]">
-            //       <Image src={file.url} alt="post" className="object-cover" sizes="234px" fill />
-            //    </div>
-            <Slider images={images} className={'mb-3 h-[240px] w-[234px]'} />
-         )}
+         {file?.url &&
+            (expanded ? (
+               //  <div className="relative h-[240px] w-[234px] overflow-hidden">
+               //    <Image src={file.url} alt="post" fill sizes="234px" />
+               //  </div>
 
-         <div className="mb-3 flex flex-col gap-2 text-sm text-white">
-            <div className="flex items-center gap-3">
-               {user.avatar ? (
+               <div className="relative mb-3 h-[240px] w-[234px]">
                   <Image
-                     src={user.avatar}
-                     alt={user.userName}
-                     width={32}
-                     height={32}
-                     className="rounded-full object-cover"
+                     src={file.url}
+                     alt="post"
+                     fill
+                     sizes="234px"
+                     style={{
+                        clipPath: 'inset(0 0 120px 0)',
+                     }}
                   />
-               ) : (
-                  <div
-                     className={
-                        'bg-dark-100 flex h-[32px] w-[32px] items-center justify-center rounded-full'
-                     }
-                  >
-                     <PostOutlineIcon width={20} height={20} />
-                  </div>
-               )}
-               <Typography as="span" variant="h3">
-                  {user.userName}
+               </div>
+            ) : (
+               <Slider images={images} className="mb-3 h-[240px] w-[234px]" />
+            ))}
+
+         <div
+            className={cn(
+               /*                'transition-all duration-300',
+               expanded && 'translate-y-[-120px]' // ← transform вместо margin */
+               expanded && 'mt-[-120px]'
+            )}
+         >
+            <div className="mb-3 flex flex-col gap-2 text-sm text-white">
+               <div className="flex items-center gap-3">
+                  {user.avatar ? (
+                     <Image
+                        src={user.avatar}
+                        alt={user.userName}
+                        width={32}
+                        height={32}
+                        className="rounded-full object-cover"
+                     />
+                  ) : (
+                     <div
+                        className={
+                           'bg-dark-100 flex h-[32px] w-[32px] items-center justify-center rounded-full'
+                        }
+                     >
+                        <PostOutlineIcon width={20} height={20} />
+                     </div>
+                  )}
+                  <Typography as="span" variant="h3">
+                     {user.userName}
+                  </Typography>
+               </div>
+               <Typography as="span" variant="smallRegular" className="text-light-900">
+                  {createdAtPost}
                </Typography>
             </div>
-            <Typography as="span" variant="smallRegular" className="text-light-900">
-               {createdAtPost}
-            </Typography>
-         </div>
 
-         <div>{description && <Typography variant="captionRegular">{description}</Typography>}</div>
+            <div className="">
+               <Typography as="p" variant="captionRegular" className="inline">
+                  {visibleText}
+                  {shouldTruncate && !expanded && description.length > SHORT_LIMIT && '...'}
+               </Typography>
+
+               {showHideButton && (
+                  <button
+                     type="button"
+                     onClick={() => setExpanded(prev => !prev)}
+                     //через cn почему-то неприменяется text-s
+                     className={clsx(
+                        'text-s text-misc-primary-500 leading-m font-regular ml-1',
+                        'cursor-pointer underline hover:underline focus:outline-none'
+                     )}
+                  >
+                     {expanded ? 'Hide' : 'Show more'}
+                  </button>
+               )}
+            </div>
+         </div>
       </Card>
    )
 }

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -5,21 +5,9 @@ import { Card } from '@/shared/components/Card'
 import { Slider } from '@/shared/components/Slider'
 import { Typography } from '@/shared/components/Typography'
 import { cn } from '@/shared/lib'
+import { PostProps } from '@/shared/schema/postsSchema'
 import clsx from 'clsx'
 import { useState } from 'react'
-
-export type PostProps = {
-   postId: string
-   description: string | null
-   location: string | null
-   file: { url: string }
-   createdAt: string
-   user: {
-      userId: string
-      userName: string
-      avatar: string | null
-   }
-}
 
 export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
    const createdAtPost = new Date(createdAt).toLocaleString('en-EN', {
@@ -52,7 +40,7 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
             <div
                className={cn(
                   'mb-3 w-[234px] overflow-hidden transition-all duration-300',
-                  expanded ? 'h-[111px]' : 'h-[240px]'
+                  expanded ? 'h-[115px]' : 'h-[240px]'
                )}
             >
                <Slider images={images} disabled={expanded} className="h-[240px] w-[234px]" />

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -31,12 +31,12 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
       minute: '2-digit',
    })
 
+   const SHORT_LIMIT = 90
+   const EXTENDED_LIMIT = 270
+
    const [expanded, setExpanded] = useState(false)
 
    if (!description) description = ''
-
-   const SHORT_LIMIT = 90
-   const EXTENDED_LIMIT = 235
 
    const shouldTruncate = description.length > SHORT_LIMIT
    const visibleText = expanded
@@ -48,11 +48,11 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
    const images = [file.url, file.url, file.url]
 
    return (
-      <Card withBaseStyles={false} className="h-[391px] w-[234px] overflow-hidden">
+      <Card withBaseStyles={false} className="h-[400px] w-[234px] overflow-hidden">
          {file?.url && (
             <div
                className={cn(
-                  'mb-3 w-[234px] overflow-hidden',
+                  'mb-3 w-[234px] overflow-hidden transition-all duration-300',
                   expanded ? 'h-[120px]' : 'h-[240px]'
                )}
             >
@@ -88,7 +88,7 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
             </Typography>
          </div>
 
-         <div className="">
+         <div>
             <Typography as="p" variant="captionRegular" className="inline">
                {visibleText}
                {shouldTruncate && !expanded && description.length > SHORT_LIMIT && '...'}
@@ -101,7 +101,7 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
                   onClick={() => setExpanded(prev => !prev)}
                   className={clsx(
                      'text-s text-misc-primary-500 leading-m font-regular ml-1',
-                     'cursor-pointer underline hover:underline focus:outline-none'
+                     'cursor-pointer underline hover:underline'
                   )}
                >
                   {expanded ? 'Hide' : 'Show more'}

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -1,0 +1,59 @@
+import { Card } from '@/shared/components/Card'
+import Image from 'next/image'
+
+export type PostProps = {
+   postId: string
+   description: string | null
+   location: string | null
+   file: { url: string }
+   createdAt: string
+   user: {
+      userId: string
+      userName: string
+      avatar: string | null
+   }
+}
+
+export const CardPost = ({ description, location, file, createdAt, user }: PostProps) => {
+   const createdAtPost = new Date(createdAt).toLocaleString('ru-RU', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+   })
+
+   return (
+      <Card className="bg-dark-500 h-[391px] w-[234px] overflow-hidden">
+         {file?.url && (
+            <div className="relative h-[240px] w-[234px]">
+               <Image src={file.url} alt="post" className="object-cover" sizes="234px" fill />
+            </div>
+            //<Slider images={images} className={'h-[240px] w-[234px]'} />
+         )}
+
+         {/* Информация о пользователе */}
+         <div className="flex items-center gap-2 p-2 text-sm text-white">
+            {user.avatar && (
+               <Image
+                  src={user.avatar}
+                  alt={user.userName}
+                  width={32}
+                  height={32}
+                  className="rounded-full object-cover"
+               />
+            )}
+            <div className="flex flex-col">
+               <span className="font-medium">{user.userName}</span>
+               <span className="text-xs text-gray-400">{createdAtPost}</span>
+            </div>
+         </div>
+
+         {/* Описание поста */}
+         <div className="p-2 text-sm text-gray-400">
+            {description && <p>{description}</p>}
+            {location && <p className="text-xs text-gray-500">{location}</p>}
+         </div>
+      </Card>
+   )
+}

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { Avatar } from '@/shared/components/Avatar'
-import { Card } from '@/shared/components/Card'
 import { Slider } from '@/shared/components/Slider'
 import { Typography } from '@/shared/components/Typography'
 import { cn } from '@/shared/lib'
@@ -21,29 +20,33 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
    const SHORT_LIMIT = 90
    const EXTENDED_LIMIT = 270
 
-   const [expanded, setExpanded] = useState(false)
+   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
    if (!description) description = ''
 
    const shouldTruncate = description.length > SHORT_LIMIT
-   const visibleText = expanded
+   const visibleText = isDescriptionExpanded
       ? description.slice(0, EXTENDED_LIMIT)
       : description.slice(0, SHORT_LIMIT)
 
-   const showHideButton = shouldTruncate && description.length > SHORT_LIMIT
+   const isToggleButtonVisible = shouldTruncate && description.length > SHORT_LIMIT
 
    const images = [file.url, file.url, file.url]
 
    return (
-      <Card withBaseStyles={false} className="h-[400px] w-[234px] overflow-hidden">
+      <div className="h-[400px] w-[234px] overflow-hidden">
          {file?.url && (
             <div
                className={cn(
                   'mb-3 w-[234px] overflow-hidden transition-all duration-300',
-                  expanded ? 'h-[115px]' : 'h-[240px]'
+                  isDescriptionExpanded ? 'h-[115px]' : 'h-[240px]'
                )}
             >
-               <Slider images={images} disabled={expanded} className="h-[240px] w-[234px]" />
+               <Slider
+                  images={images}
+                  disabled={isDescriptionExpanded}
+                  className="h-[240px] w-[234px]"
+               />
             </div>
          )}
 
@@ -62,23 +65,25 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
          <div>
             <Typography as="p" variant="captionRegular" className="inline">
                {visibleText}
-               {shouldTruncate && !expanded && description.length > SHORT_LIMIT && '...'}
-               {shouldTruncate && expanded && description.length > SHORT_LIMIT && '..'}
+               {shouldTruncate &&
+                  !isDescriptionExpanded &&
+                  description.length > SHORT_LIMIT &&
+                  '...'}
+               {shouldTruncate && isDescriptionExpanded && description.length > SHORT_LIMIT && '..'}
             </Typography>
 
-            {showHideButton && (
+            {isToggleButtonVisible && (
                <button
-                  type="button"
-                  onClick={() => setExpanded(prev => !prev)}
+                  onClick={() => setIsDescriptionExpanded(prev => !prev)}
                   className={clsx(
-                     'text-s text-misc-primary-500 leading-m font-regular ml-1',
+                     'text-s text-accent-500 leading-m font-regular ml-1',
                      'cursor-pointer underline hover:underline'
                   )}
                >
-                  {expanded ? 'Hide' : 'Show more'}
+                  {isDescriptionExpanded ? 'Hide' : 'Show more'}
                </button>
             )}
          </div>
-      </Card>
+      </div>
    )
 }

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -22,8 +22,6 @@ export type PostProps = {
    }
 }
 
-//const images = ['./public/404.jpg', './public/logo-light.png', './public/logo-dark.png']
-
 export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
    const createdAtPost = new Date(createdAt).toLocaleString('en-EN', {
       day: '2-digit',
@@ -37,9 +35,8 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
 
    if (!description) description = ''
 
-   // базовые лимиты
    const SHORT_LIMIT = 90
-   const EXTENDED_LIMIT = 240
+   const EXTENDED_LIMIT = 235
 
    const shouldTruncate = description.length > SHORT_LIMIT
    const visibleText = expanded
@@ -49,85 +46,67 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
    const showHideButton = shouldTruncate && description.length > SHORT_LIMIT
 
    const images = [file.url, file.url, file.url]
-   //h-[391px]
+
    return (
       <Card withBaseStyles={false} className="h-[391px] w-[234px] overflow-hidden">
-         {file?.url &&
-            (expanded ? (
-               //  <div className="relative h-[240px] w-[234px] overflow-hidden">
-               //    <Image src={file.url} alt="post" fill sizes="234px" />
-               //  </div>
-
-               <div className="relative mb-3 h-[240px] w-[234px]">
-                  <Image
-                     src={file.url}
-                     alt="post"
-                     fill
-                     sizes="234px"
-                     style={{
-                        clipPath: 'inset(0 0 120px 0)',
-                     }}
-                  />
-               </div>
-            ) : (
-               <Slider images={images} className="mb-3 h-[240px] w-[234px]" />
-            ))}
-
-         <div
-            className={cn(
-               /*                'transition-all duration-300',
-               expanded && 'translate-y-[-120px]' // ← transform вместо margin */
-               expanded && 'mt-[-120px]'
-            )}
-         >
-            <div className="mb-3 flex flex-col gap-2 text-sm text-white">
-               <div className="flex items-center gap-3">
-                  {user.avatar ? (
-                     <Image
-                        src={user.avatar}
-                        alt={user.userName}
-                        width={32}
-                        height={32}
-                        className="rounded-full object-cover"
-                     />
-                  ) : (
-                     <div
-                        className={
-                           'bg-dark-100 flex h-[32px] w-[32px] items-center justify-center rounded-full'
-                        }
-                     >
-                        <PostOutlineIcon width={20} height={20} />
-                     </div>
-                  )}
-                  <Typography as="span" variant="h3">
-                     {user.userName}
-                  </Typography>
-               </div>
-               <Typography as="span" variant="smallRegular" className="text-light-900">
-                  {createdAtPost}
-               </Typography>
-            </div>
-
-            <div className="">
-               <Typography as="p" variant="captionRegular" className="inline">
-                  {visibleText}
-                  {shouldTruncate && !expanded && description.length > SHORT_LIMIT && '...'}
-               </Typography>
-
-               {showHideButton && (
-                  <button
-                     type="button"
-                     onClick={() => setExpanded(prev => !prev)}
-                     //через cn почему-то неприменяется text-s
-                     className={clsx(
-                        'text-s text-misc-primary-500 leading-m font-regular ml-1',
-                        'cursor-pointer underline hover:underline focus:outline-none'
-                     )}
-                  >
-                     {expanded ? 'Hide' : 'Show more'}
-                  </button>
+         {file?.url && (
+            <div
+               className={cn(
+                  'mb-3 w-[234px] overflow-hidden',
+                  expanded ? 'h-[120px]' : 'h-[240px]'
                )}
+            >
+               <Slider images={images} disabled={expanded} className="h-[240px] w-[234px]" />
             </div>
+         )}
+
+         <div className="mb-3 flex flex-col gap-2">
+            <div className="flex items-center gap-3">
+               {user.avatar ? (
+                  <Image
+                     src={user.avatar}
+                     alt={user.userName}
+                     width={32}
+                     height={32}
+                     className="rounded-full object-cover"
+                  />
+               ) : (
+                  <div
+                     className={
+                        'bg-dark-100 flex h-[32px] w-[32px] items-center justify-center rounded-full'
+                     }
+                  >
+                     <PostOutlineIcon width={20} height={20} />
+                  </div>
+               )}
+               <Typography as="span" variant="h3">
+                  {user.userName}
+               </Typography>
+            </div>
+            <Typography as="span" variant="smallRegular" className="text-light-900">
+               {createdAtPost}
+            </Typography>
+         </div>
+
+         <div className="">
+            <Typography as="p" variant="captionRegular" className="inline">
+               {visibleText}
+               {shouldTruncate && !expanded && description.length > SHORT_LIMIT && '...'}
+               {shouldTruncate && expanded && description.length > SHORT_LIMIT && '..'}
+            </Typography>
+
+            {showHideButton && (
+               <button
+                  type="button"
+                  onClick={() => setExpanded(prev => !prev)}
+                  className={clsx(
+                     'text-s text-misc-primary-500 leading-m font-regular ml-1',
+                     'cursor-pointer underline hover:underline focus:outline-none'
+                  )}
+               >
+                  {expanded ? 'Hide' : 'Show more'}
+               </button>
+            )}
          </div>
       </Card>
    )

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -53,14 +53,14 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
             <div
                className={cn(
                   'mb-3 w-[234px] overflow-hidden transition-all duration-300',
-                  expanded ? 'h-[120px]' : 'h-[240px]'
+                  expanded ? 'h-[115px]' : 'h-[240px]'
                )}
             >
                <Slider images={images} disabled={expanded} className="h-[240px] w-[234px]" />
             </div>
          )}
 
-         <div className="mb-3 flex flex-col gap-2">
+         <div className="flex flex-col gap-2">
             <div className="flex items-center gap-3">
                {user.avatar ? (
                   <Image

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -1,6 +1,8 @@
 import { Card } from '@/shared/components/Card'
 import { Slider } from '@/shared/components/Slider'
+import { PostOutlineIcon } from '@/shared/icons'
 import Image from 'next/image'
+import { Typography } from '@/shared/components/Typography'
 
 export type PostProps = {
    postId: string
@@ -17,8 +19,8 @@ export type PostProps = {
 
 //const images = ['./public/404.jpg', './public/logo-light.png', './public/logo-dark.png']
 
-export const CardPost = ({ description, location, file, createdAt, user }: PostProps) => {
-   const createdAtPost = new Date(createdAt).toLocaleString('ru-RU', {
+export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
+   const createdAtPost = new Date(createdAt).toLocaleString('en-EN', {
       day: '2-digit',
       month: 'short',
       year: 'numeric',
@@ -26,39 +28,46 @@ export const CardPost = ({ description, location, file, createdAt, user }: PostP
       minute: '2-digit',
    })
 
-   const images = [file.url]
+   const images = [file.url, file.url, file.url]
 
    return (
-      <Card className="bg-dark-500 h-[391px] w-[234px] overflow-hidden">
+      <Card withBaseStyles={false} className="h-[391px] w-[234px] overflow-hidden">
          {file?.url && (
             //   <div className="relative h-[240px] w-[234px]">
             //       <Image src={file.url} alt="post" className="object-cover" sizes="234px" fill />
             //    </div>
-            <Slider images={images} className={'h-[240px] w-[234px]'} />
+            <Slider images={images} className={'mb-3 h-[240px] w-[234px]'} />
          )}
 
-         {/* Информация о пользователе */}
-         <div className="flex items-center gap-2 p-2 text-sm text-white">
-            {user.avatar && (
-               <Image
-                  src={user.avatar}
-                  alt={user.userName}
-                  width={32}
-                  height={32}
-                  className="rounded-full object-cover"
-               />
-            )}
-            <div className="flex flex-col">
-               <span className="font-medium">{user.userName}</span>
-               <span className="text-xs text-gray-400">{createdAtPost}</span>
+         <div className="mb-3 flex flex-col gap-2 text-sm text-white">
+            <div className="flex items-center gap-3">
+               {user.avatar ? (
+                  <Image
+                     src={user.avatar}
+                     alt={user.userName}
+                     width={32}
+                     height={32}
+                     className="rounded-full object-cover"
+                  />
+               ) : (
+                  <div
+                     className={
+                        'bg-dark-100 flex h-[32px] w-[32px] items-center justify-center rounded-full'
+                     }
+                  >
+                     <PostOutlineIcon width={20} height={20} />
+                  </div>
+               )}
+               <Typography as="span" variant="h3">
+                  {user.userName}
+               </Typography>
             </div>
+            <Typography as="span" variant="smallRegular" className="text-light-900">
+               {createdAtPost}
+            </Typography>
          </div>
 
-         {/* Описание поста */}
-         <div className="p-2 text-sm text-gray-400">
-            {description && <p>{description}</p>}
-            {location && <p className="text-xs text-gray-500">{location}</p>}
-         </div>
+         <div>{description && <Typography variant="captionRegular">{description}</Typography>}</div>
       </Card>
    )
 }

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -1,89 +1,37 @@
 'use client'
 
-import { Avatar } from '@/shared/components/Avatar'
-import { Slider } from '@/shared/components/Slider'
-import { Typography } from '@/shared/components/Typography'
-import { cn } from '@/shared/lib'
-import { PostProps } from '@/shared/schema/postsSchema'
-import clsx from 'clsx'
-import { useState } from 'react'
+import { LastPostProps } from '@/shared/schema'
+import { useEffect, useState } from 'react'
+import { formatDistanceToNow } from 'date-fns'
+import { PhotoSlider } from './PhotoSlider'
+import { UserBlock } from './UserBlock'
+import { DescriptionBlock } from './DescriptionBlock'
 
-export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
-   const createdAtPost = new Date(createdAt).toLocaleString('en-EN', {
-      day: '2-digit',
-      month: 'short',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-   })
-
-   const SHORT_LIMIT = 90
-   const EXTENDED_LIMIT = 270
-
+export const CardPost = ({ description, file, createdAt, user }: LastPostProps) => {
+   const [relativeTime, setRelativeTime] = useState(
+      formatDistanceToNow(new Date(createdAt), { addSuffix: true })
+   )
    const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
+   useEffect(() => {
+      const interval = setInterval(() => {
+         setRelativeTime(formatDistanceToNow(new Date(createdAt), { addSuffix: true }))
+      }, 60_000)
+      return () => clearInterval(interval)
+   }, [createdAt])
+
    if (!description) description = ''
-
-   const shouldTruncate = description.length > SHORT_LIMIT
-   const visibleText = isDescriptionExpanded
-      ? description.slice(0, EXTENDED_LIMIT)
-      : description.slice(0, SHORT_LIMIT)
-
-   const isToggleButtonVisible = shouldTruncate && description.length > SHORT_LIMIT
-
    const images = [file.url, file.url, file.url]
 
    return (
-      <div className="h-[400px] w-[234px] overflow-hidden">
-         {file?.url && (
-            <div
-               className={cn(
-                  'mb-3 w-[234px] overflow-hidden transition-all duration-300',
-                  isDescriptionExpanded ? 'h-[115px]' : 'h-[240px]'
-               )}
-            >
-               <Slider
-                  images={images}
-                  disabled={isDescriptionExpanded}
-                  className="h-[240px] w-[234px]"
-               />
-            </div>
-         )}
-
-         <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-3">
-               <Avatar src={user.avatar} alt={user.userName} />
-               <Typography as="span" variant="h3">
-                  {user.userName}
-               </Typography>
-            </div>
-            <Typography as="span" variant="smallRegular" className="text-light-900">
-               {createdAtPost}
-            </Typography>
-         </div>
-
-         <div>
-            <Typography as="p" variant="captionRegular" className="inline">
-               {visibleText}
-               {shouldTruncate &&
-                  !isDescriptionExpanded &&
-                  description.length > SHORT_LIMIT &&
-                  '...'}
-               {shouldTruncate && isDescriptionExpanded && description.length > SHORT_LIMIT && '..'}
-            </Typography>
-
-            {isToggleButtonVisible && (
-               <button
-                  onClick={() => setIsDescriptionExpanded(prev => !prev)}
-                  className={clsx(
-                     'text-s text-accent-500 leading-m font-regular ml-1',
-                     'cursor-pointer underline hover:underline'
-                  )}
-               >
-                  {isDescriptionExpanded ? 'Hide' : 'Show more'}
-               </button>
-            )}
-         </div>
+      <div className="h-[391px] w-[234px] overflow-hidden">
+         {file?.url && <PhotoSlider images={images} expanded={isDescriptionExpanded} />}
+         <UserBlock avatar={user.avatar} userName={user.userName} relativeTime={relativeTime} />
+         <DescriptionBlock
+            description={description}
+            isExpanded={isDescriptionExpanded}
+            onToggle={() => setIsDescriptionExpanded(prev => !prev)}
+         />
       </div>
    )
 }

--- a/src/entities/posts/ui/CardPost/CardPost.tsx
+++ b/src/entities/posts/ui/CardPost/CardPost.tsx
@@ -1,12 +1,11 @@
 'use client'
 
+import { Avatar } from '@/shared/components/Avatar'
 import { Card } from '@/shared/components/Card'
 import { Slider } from '@/shared/components/Slider'
 import { Typography } from '@/shared/components/Typography'
-import { PostOutlineIcon } from '@/shared/icons'
 import { cn } from '@/shared/lib'
 import clsx from 'clsx'
-import Image from 'next/image'
 import { useState } from 'react'
 
 export type PostProps = {
@@ -53,7 +52,7 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
             <div
                className={cn(
                   'mb-3 w-[234px] overflow-hidden transition-all duration-300',
-                  expanded ? 'h-[115px]' : 'h-[240px]'
+                  expanded ? 'h-[111px]' : 'h-[240px]'
                )}
             >
                <Slider images={images} disabled={expanded} className="h-[240px] w-[234px]" />
@@ -62,23 +61,7 @@ export const CardPost = ({ description, file, createdAt, user }: PostProps) => {
 
          <div className="flex flex-col gap-2">
             <div className="flex items-center gap-3">
-               {user.avatar ? (
-                  <Image
-                     src={user.avatar}
-                     alt={user.userName}
-                     width={32}
-                     height={32}
-                     className="rounded-full object-cover"
-                  />
-               ) : (
-                  <div
-                     className={
-                        'bg-dark-100 flex h-[32px] w-[32px] items-center justify-center rounded-full'
-                     }
-                  >
-                     <PostOutlineIcon width={20} height={20} />
-                  </div>
-               )}
+               <Avatar src={user.avatar} alt={user.userName} />
                <Typography as="span" variant="h3">
                   {user.userName}
                </Typography>

--- a/src/entities/posts/ui/CardPost/DescriptionBlock.tsx
+++ b/src/entities/posts/ui/CardPost/DescriptionBlock.tsx
@@ -1,0 +1,45 @@
+import { Typography } from '@/shared/components/Typography/Typography'
+import clsx from 'clsx'
+
+type Props = {
+   description: string
+   isExpanded: boolean
+   onToggle: () => void
+   shortLimit?: number
+   extendedLimit?: number
+}
+
+export const DescriptionBlock = ({
+   description,
+   isExpanded,
+   onToggle,
+   shortLimit = 90,
+   extendedLimit = 270,
+}: Props) => {
+   const shouldTruncate = description.length > shortLimit
+   const visibleText = isExpanded
+      ? description.slice(0, extendedLimit)
+      : description.slice(0, shortLimit)
+
+   return (
+      <div>
+         <Typography as="p" variant="captionRegular" className="inline">
+            {visibleText}
+            {shouldTruncate && !isExpanded && '...'}
+            {shouldTruncate && isExpanded && '..'}
+         </Typography>
+
+         {shouldTruncate && (
+            <button
+               onClick={onToggle}
+               className={clsx(
+                  'text-s text-accent-500 leading-m font-regular ml-1',
+                  'cursor-pointer underline hover:underline'
+               )}
+            >
+               {isExpanded ? 'Hide' : 'Show more'}
+            </button>
+         )}
+      </div>
+   )
+}

--- a/src/entities/posts/ui/CardPost/PhotoSlider.tsx
+++ b/src/entities/posts/ui/CardPost/PhotoSlider.tsx
@@ -1,0 +1,19 @@
+import { Slider } from '@/shared/components/Slider'
+import { cn } from '@/shared/lib'
+
+type Props = {
+   images: string[]
+   expanded: boolean
+   onToggle?: () => void
+}
+
+export const PhotoSlider = ({ images, expanded }: Props) => (
+   <div
+      className={cn(
+         'mb-3 w-[234px] overflow-hidden transition-all duration-300',
+         expanded ? 'h-[115px]' : 'h-[240px]'
+      )}
+   >
+      <Slider images={images} disabled={expanded} className="h-[240px] w-[234px]" />
+   </div>
+)

--- a/src/entities/posts/ui/CardPost/UserBlock.tsx
+++ b/src/entities/posts/ui/CardPost/UserBlock.tsx
@@ -1,0 +1,22 @@
+import { Avatar } from '@/shared/components/Avatar'
+import { Typography } from '@/shared/components/Typography'
+
+type Props = {
+   avatar?: string | null
+   userName: string
+   relativeTime: string
+}
+
+export const UserBlock = ({ avatar, userName, relativeTime }: Props) => (
+   <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-3">
+         <Avatar src={avatar} alt={userName} />
+         <Typography as="span" variant="h3">
+            {userName}
+         </Typography>
+      </div>
+      <Typography as="span" variant="smallRegular" className="text-light-900">
+         {relativeTime}
+      </Typography>
+   </div>
+)

--- a/src/entities/posts/ui/CardPost/index.ts
+++ b/src/entities/posts/ui/CardPost/index.ts
@@ -1,0 +1,1 @@
+export * from './CardPost'

--- a/src/entities/posts/ui/CardPost/index.ts
+++ b/src/entities/posts/ui/CardPost/index.ts
@@ -1,1 +1,4 @@
 export * from './CardPost'
+export * from './DescriptionBlock'
+export * from './PhotoSlider'
+export * from './UserBlock'

--- a/src/shared/components/Avatar/Avatar.stories.tsx
+++ b/src/shared/components/Avatar/Avatar.stories.tsx
@@ -7,6 +7,7 @@ const meta = {
    parameters: {
       layout: 'centered',
    },
+   tags: ['autodocs'],
 } satisfies Meta<typeof Avatar>
 
 export default meta
@@ -16,12 +17,12 @@ export const WithAvatar: Story = {
    args: {
       src: './public/logo-light.png',
       alt: 'John Doe',
-      size: 48,
+      size: 'md',
    },
 }
 
 export const Default: Story = {
    args: {
-      size: 48,
+      size: 'md',
    },
 }

--- a/src/shared/components/Avatar/Avatar.stories.tsx
+++ b/src/shared/components/Avatar/Avatar.stories.tsx
@@ -1,0 +1,27 @@
+import { Avatar } from './Avatar'
+import { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+const meta = {
+   title: 'Components/Avatar',
+   component: Avatar,
+   parameters: {
+      layout: 'centered',
+   },
+} satisfies Meta<typeof Avatar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const WithAvatar: Story = {
+   args: {
+      src: './public/logo-light.png',
+      alt: 'John Doe',
+      size: 48,
+   },
+}
+
+export const Default: Story = {
+   args: {
+      size: 48,
+   },
+}

--- a/src/shared/components/Avatar/Avatar.tsx
+++ b/src/shared/components/Avatar/Avatar.tsx
@@ -1,0 +1,31 @@
+import { PostOutlineIcon } from '@/shared/icons'
+import Image from 'next/image'
+
+type Props = {
+   src?: string | null
+   alt?: string
+   size?: number
+}
+
+export const Avatar = ({ src, alt = 'Avatar', size = 36 }: Props) => {
+   if (src) {
+      return (
+         <Image
+            src={src}
+            alt={alt}
+            width={size}
+            height={size}
+            className="rounded-full object-cover"
+         />
+      )
+   }
+
+   return (
+      <div
+         className="bg-dark-100 flex items-center justify-center rounded-full"
+         style={{ width: size, height: size }}
+      >
+         <PostOutlineIcon width={size * 0.625} height={size * 0.625} />
+      </div>
+   )
+}

--- a/src/shared/components/Avatar/Avatar.tsx
+++ b/src/shared/components/Avatar/Avatar.tsx
@@ -1,31 +1,39 @@
 import { PostOutlineIcon } from '@/shared/icons'
+import { cn } from '@/shared/lib'
 import Image from 'next/image'
+
+type AvatarSize = 'sm' | 'md' | 'lg'
 
 type Props = {
    src?: string | null
    alt?: string
-   size?: number
+   size?: AvatarSize
 }
 
-export const Avatar = ({ src, alt = 'Avatar', size = 36 }: Props) => {
+const variantSize: Record<AvatarSize, { px: number; class: string }> = {
+   sm: { px: 36, class: 'w-[36px] h-[36px]' },
+   md: { px: 54, class: 'w-[54px] h-[54px]' },
+   lg: { px: 204, class: 'w-[204px] h-[204px]' },
+}
+
+export const Avatar = ({ src, alt = 'Avatar', size = 'sm' }: Props) => {
+   const { px: pixelSize, class: sizeClasses } = variantSize[size]
+
    if (src) {
       return (
          <Image
             src={src}
             alt={alt}
-            width={size}
-            height={size}
+            width={pixelSize}
+            height={pixelSize}
             className="rounded-full object-cover"
          />
       )
    }
 
    return (
-      <div
-         className="bg-dark-100 flex items-center justify-center rounded-full"
-         style={{ width: size, height: size }}
-      >
-         <PostOutlineIcon width={size * 0.625} height={size * 0.625} />
+      <div className={cn('bg-dark-100 flex items-center justify-center rounded-full', sizeClasses)}>
+         <PostOutlineIcon width={pixelSize * 0.625} height={pixelSize * 0.625} />
       </div>
    )
 }

--- a/src/shared/components/Avatar/index.ts
+++ b/src/shared/components/Avatar/index.ts
@@ -1,0 +1,1 @@
+export * from './Avatar'

--- a/src/shared/components/Card/Card.tsx
+++ b/src/shared/components/Card/Card.tsx
@@ -3,18 +3,15 @@ import { clsx } from 'clsx'
 
 type Props<T extends ElementType = 'div'> = {
    as?: T
-   withBaseStyles?: boolean
 } & ComponentPropsWithRef<T>
 
-export const Card = <T extends ElementType = 'div'>({
-   as,
-   className,
-   withBaseStyles = true,
-   ...rest
-}: Props<T>) => {
+export const Card = <T extends ElementType = 'div'>({ as, className, ...rest }: Props<T>) => {
    const Component = as || 'div'
 
-   const base = withBaseStyles ? 'bg-dark-500 border-dark-300 rounded-xs border' : ''
-
-   return <Component className={clsx(base, className)} {...rest} />
+   return (
+      <Component
+         className={clsx('bg-dark-500 border-dark-300 rounded-xs border', className)}
+         {...rest}
+      />
+   )
 }

--- a/src/shared/components/Card/Card.tsx
+++ b/src/shared/components/Card/Card.tsx
@@ -3,15 +3,18 @@ import { clsx } from 'clsx'
 
 type Props<T extends ElementType = 'div'> = {
    as?: T
+   withBaseStyles?: boolean
 } & ComponentPropsWithRef<T>
 
-export const Card = <T extends ElementType = 'div'>({ as, className, ...rest }: Props<T>) => {
+export const Card = <T extends ElementType = 'div'>({
+   as,
+   className,
+   withBaseStyles = true,
+   ...rest
+}: Props<T>) => {
    const Component = as || 'div'
 
-   return (
-      <Component
-         className={clsx('bg-dark-500 border-dark-300 rounded-xs border', className)}
-         {...rest}
-      />
-   )
+   const base = withBaseStyles ? 'bg-dark-500 border-dark-300 rounded-xs border' : ''
+
+   return <Component className={clsx(base, className)} {...rest} />
 }

--- a/src/shared/components/Loader/Loader.tsx
+++ b/src/shared/components/Loader/Loader.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export function Loader({
    size = '2.8rem',
-   color = 'var(--color-secondary-200)',
+   color = 'var(--color-accent-500)',
    speed = 0.9,
    fullscreen = true,
 }: Props) {

--- a/src/shared/components/PageContainer/ServerPageContainer.tsx
+++ b/src/shared/components/PageContainer/ServerPageContainer.tsx
@@ -1,5 +1,6 @@
+import { ReactNode } from 'react'
 import { PageContainer } from './PageContainer'
 
-export default function ServerPageContainer({ children }: { children: React.ReactNode }) {
+export default function ServerPageContainer({ children }: { children: ReactNode }) {
    return <PageContainer>{children}</PageContainer>
 }

--- a/src/shared/components/PageContainer/ServerPageContainer.tsx
+++ b/src/shared/components/PageContainer/ServerPageContainer.tsx
@@ -1,0 +1,6 @@
+// src/shared/components/ServerPageContainer.tsx
+import { PageContainer } from './PageContainer'
+
+export default function ServerPageContainer({ children }: { children: React.ReactNode }) {
+   return <PageContainer>{children}</PageContainer>
+}

--- a/src/shared/components/PageContainer/ServerPageContainer.tsx
+++ b/src/shared/components/PageContainer/ServerPageContainer.tsx
@@ -1,4 +1,3 @@
-// src/shared/components/ServerPageContainer.tsx
 import { PageContainer } from './PageContainer'
 
 export default function ServerPageContainer({ children }: { children: React.ReactNode }) {

--- a/src/shared/components/PageContainer/index.ts
+++ b/src/shared/components/PageContainer/index.ts
@@ -1,1 +1,2 @@
 export * from './PageContainer'
+export * from './ServerPageContainer'

--- a/src/shared/components/Slider/Slider.tsx
+++ b/src/shared/components/Slider/Slider.tsx
@@ -14,9 +14,10 @@ import Image from 'next/image'
 type Props = {
    images: string[]
    className?: string
+   disabled?: boolean
 }
 
-export const Slider = ({ images, className }: Props) => {
+export const Slider = ({ images, className, disabled }: Props) => {
    const { sliderRef, instanceRef, currentSlide, slides } = useSlider()
 
    const onNextSlideHandler = () => instanceRef.current?.next()
@@ -33,12 +34,17 @@ export const Slider = ({ images, className }: Props) => {
             ))}
          </SliderContent>
 
-         {images.length > 1 && (
+         {/* !disabled - condition for CardPost, for cut image */}
+         {images.length > 1 && !disabled && (
             <>
-               <SliderArrow className={'left-4'} onClick={onPrevSlideHandler}>
+               <SliderArrow className={'left-4'} onClick={onPrevSlideHandler} disabled={disabled}>
                   <ArrowLeftIcon className={'group-hover:text-accent-300'} />
                </SliderArrow>
-               <SliderArrow className={'right-[4px]'} onClick={onNextSlideHandler}>
+               <SliderArrow
+                  className={'right-[4px]'}
+                  onClick={onNextSlideHandler}
+                  disabled={disabled}
+               >
                   <ArrowRightIcon className={'group-hover:text-accent-300'} />
                </SliderArrow>
 

--- a/src/shared/components/Slider/Slider.tsx
+++ b/src/shared/components/Slider/Slider.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import {
    SliderArrow,
    SliderContent,

--- a/src/shared/components/Slider/useSlider.ts
+++ b/src/shared/components/Slider/useSlider.ts
@@ -1,3 +1,5 @@
+'use client'
+
 import { useState } from 'react'
 import { useKeenSlider } from 'keen-slider/react'
 

--- a/src/shared/components/Typography/variantClasses.ts
+++ b/src/shared/components/Typography/variantClasses.ts
@@ -10,7 +10,7 @@ export const variantClasses: Record<TypographyVariant, string> = {
    captionRegular: 'text-s font-regular leading-m',
    captionMedium: 'text-s font-medium leading-m',
    captionBold: 'text-s font-bold leading-m',
-   smallRegular: 'text-xs font-regular  leading-s',
+   smallRegular: 'text-xs font-regular leading-s',
    smallBold: 'text-xs font-semibold leading-s',
    linkRegular: 'cursor-pointer text-s font-regular text-accent-500 underline leading-m',
    linkSmall: 'cursor-pointer text-s font-regular text-accent-500 underline leading-s',

--- a/src/shared/constants/api.ts
+++ b/src/shared/constants/api.ts
@@ -1,8 +1,9 @@
-import { AuthEndpoints } from '../enums'
+import { AuthEndpoints, PostsEndpoints } from '../enums'
 
 export const TOKEN = 'accessToken'
 
 export const apiMap = {
    loginGoogle: `${process.env.NEXT_PUBLIC_BASE_URL}${AuthEndpoints.loginGoogle}`,
    loginGitHub: `${process.env.NEXT_PUBLIC_BASE_URL}${AuthEndpoints.loginGitHub}`,
+   lastPosts: `${process.env.NEXT_PUBLIC_BASE_URL}${PostsEndpoints.lastPosts}`,
 }

--- a/src/shared/enums/index.ts
+++ b/src/shared/enums/index.ts
@@ -1,2 +1,3 @@
 export * from './routes'
 export * from './authEndpoints'
+export * from './postsEndpoints'

--- a/src/shared/enums/postsEndpoints.ts
+++ b/src/shared/enums/postsEndpoints.ts
@@ -1,0 +1,3 @@
+export enum PostsEndpoints {
+   lastPosts = '/public/posts/last-posts',
+}

--- a/src/shared/schema/index.ts
+++ b/src/shared/schema/index.ts
@@ -1,2 +1,3 @@
 export * from './authValidation'
 export * from './imgSchema'
+export * from './'

--- a/src/shared/schema/index.ts
+++ b/src/shared/schema/index.ts
@@ -1,3 +1,3 @@
 export * from './authValidation'
 export * from './imgSchema'
-export * from './'
+export * from './lastPostsSchema'

--- a/src/shared/schema/lastPostsSchema.ts
+++ b/src/shared/schema/lastPostsSchema.ts
@@ -20,7 +20,7 @@ export const fileSchema = z.object({
    ),
 })
 
-export const postSchema = z.object({
+export const lastPostSchema = z.object({
    postId: z.string(),
    description: z.string().nullable(),
    location: z.string().nullable(),
@@ -29,8 +29,8 @@ export const postSchema = z.object({
    user: userSchema,
 })
 
-export const postsSchema = z.object({
-   posts: z.array(postSchema),
+export const lastPostsSchema = z.object({
+   posts: z.array(lastPostSchema),
 })
 
-export type PostProps = z.infer<typeof postSchema>
+export type LastPostProps = z.infer<typeof lastPostSchema>

--- a/src/shared/schema/postsSchema.ts
+++ b/src/shared/schema/postsSchema.ts
@@ -1,0 +1,36 @@
+import z from 'zod'
+
+export const userSchema = z.object({
+   userId: z.string(),
+   userName: z.string(),
+   avatar: z.string().nullable(),
+})
+
+export const fileSchema = z.object({
+   url: z.string().refine(
+      val => {
+         try {
+            new URL(val)
+            return true
+         } catch {
+            return false
+         }
+      },
+      { message: 'Invalid URL' }
+   ),
+})
+
+export const postSchema = z.object({
+   postId: z.string(),
+   description: z.string().nullable(),
+   location: z.string().nullable(),
+   file: fileSchema,
+   createdAt: z.string(),
+   user: userSchema,
+})
+
+export const postsSchema = z.object({
+   posts: z.array(postSchema),
+})
+
+export type PostProps = z.infer<typeof postSchema>

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -37,6 +37,7 @@
 
     /* other colors */
     --color-primary-100: #212121;
+    --color-primary-500: #397DF6;
 
     --color-secondary-100: #4D8DF4;
     --color-secondary-200: #397DF6;

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -37,10 +37,8 @@
 
     /* other colors */
     --color-primary-100: #212121;
-    --color-primary-500: #397DF6;
 
     --color-secondary-100: #4D8DF4;
-    --color-secondary-200: #397DF6;
 
     --color-neutral-100: #B7B7B7;
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,7 @@ const config: Config = {
             misc: {
                primary: {
                   100: 'var(--color-primary-100)',
+                  500: 'var(--color-primary-500)',
                },
                secondary: {
                   100: 'var(--color-secondary-100)',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,11 +50,9 @@ const config: Config = {
             misc: {
                primary: {
                   100: 'var(--color-primary-100)',
-                  500: 'var(--color-primary-500)',
                },
                secondary: {
                   100: 'var(--color-secondary-100)',
-                  200: 'var(--color-secondary-100)',
                },
                neutral: {
                   100: 'var(--color-neutral-100)',


### PR DESCRIPTION
Добавлено отображение  4-ех постов. Посты обновляются каждую минуту.
Отдельный пост отображается через карточку - CardPost
В карточке описание отображается скрытым, при нажатии на Show more отображается еще часть описания и при этом скрывается часть картинки из карусели и дизейблится скролл на карусели, при нажатии на Hide возврат к первоначальному состоянию.
-Добавлен компонент для аварки: Avatar

-типизации картинки поста file": {"url": "string"} будет позже заменен на массив строк
-в next.config.ts добавлены хосты чтобы подгружались картинки с бека при запросе.
-в card добавлен базовый стиль чтобы можно было переопределить стили для CardPost
-добавлен ServerPageContainer чтобы использовать клиентский PageContainer на серверной странице app/page
-в Slider добавлено свойство disabled чтобы дизейблился скролинг при нажатии на Show more в карточке поста
-в Slider и useSlider добавлен 'use client' чтобы убрать ошибки совместимости серверных и клиентских компонент при вложенности

<img width="1280" height="1024" alt="cardPost" src="https://github.com/user-attachments/assets/e411aa09-1591-4356-83ee-05a4d1e18a86" />
