### PR TITLE
YAY-84 fix: add oauth_success query param check after OAuth redirect

### DIFF
--- a/src/shared/constants/index.ts
+++ b/src/shared/constants/index.ts
@@ -1,1 +1,2 @@
 export * from './api'
+export * from './queryParams'

--- a/src/shared/constants/queryParams.ts
+++ b/src/shared/constants/queryParams.ts
@@ -1,0 +1,3 @@
+export const QUERY_PARAMS = {
+   oauthSuccess: 'oauth_success',
+} as const

--- a/src/shared/store/base-query.ts
+++ b/src/shared/store/base-query.ts
@@ -8,7 +8,7 @@ import {
    type FetchBaseQueryError,
 } from '@reduxjs/toolkit/query/react'
 import { Mutex } from 'async-mutex'
-import { TOKEN } from '../constants'
+import { QUERY_PARAMS, TOKEN } from '../constants'
 
 const mutex = new Mutex()
 
@@ -38,8 +38,10 @@ export const baseQueryWithReAuth: BaseQueryFn<
 
    if (result.error && result.error.status === 401) {
       const token = localStorage.getItem(TOKEN)
+      const urlParams = new URLSearchParams(window.location.search)
+      const isOAuthSuccess = urlParams.get(QUERY_PARAMS.oauthSuccess) === 'true'
 
-      if (!token) return result
+      if (!token && !isOAuthSuccess) return result
 
       if (!mutex.isLocked()) {
          const release = await mutex.acquire()


### PR DESCRIPTION
Добавлена проверка на isOAuthSuccess. Если oauth успешно прошла, то делаем запрос за рефрешем, а не прерываем