### PR TITLE
YAY-93 fix: corrected export error in Layout

### DIFF
--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,17 +1,11 @@
 'use client'
 
+import { ReactNode } from 'react'
 import { useMeQuery } from '@/features/auth/api'
 import { cn } from '@/shared/lib'
 import { Sidebar } from '@/widgets/Sidebar'
-import { createContext, useContext } from 'react'
 
-const AuthContext = createContext<{ isAuthorized: boolean }>({
-   isAuthorized: false,
-})
-
-export const useAuth = () => useContext(AuthContext)
-
-export default function HomeLayout({ children }: { children: React.ReactNode }) {
+export default function HomeLayout({ children }: { children: ReactNode }) {
    const { data } = useMeQuery()
 
    return (

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -12,27 +12,24 @@ const AuthContext = createContext<{ isAuthorized: boolean }>({
 export const useAuth = () => useContext(AuthContext)
 
 export default function HomeLayout({ children }: { children: React.ReactNode }) {
-   const { data, isLoading } = useMeQuery()
-   const isAuthorized = !!data && !isLoading
+   const { data } = useMeQuery()
 
    return (
-      <AuthContext.Provider value={{ isAuthorized }}>
+      <div
+         className={cn(
+            'mx-auto flex w-full max-w-[1280px] px-[60px]',
+            data ? 'flex-col items-start' : 'justify-center'
+         )}
+      >
+         {data ? <Sidebar /> : null}
          <div
             className={cn(
-               'mx-auto flex w-full max-w-[1280px] px-[60px]',
-               data ? 'flex-col items-start' : 'justify-center'
+               'border-dark-300 border-l transition-all duration-300',
+               data ? 'ml-[162px]' : 'ml-0 flex justify-center border-none'
             )}
          >
-            {data ? <Sidebar /> : null}
-            <div
-               className={cn(
-                  'border-dark-300 border-l transition-all duration-300',
-                  data ? 'ml-[162px]' : 'ml-0 flex justify-center border-none'
-               )}
-            >
-               {children}
-            </div>
+            {children}
          </div>
-      </AuthContext.Provider>
+      </div>
    )
 }

--- a/src/shared/components/PageContainer/PageContainer.tsx
+++ b/src/shared/components/PageContainer/PageContainer.tsx
@@ -4,13 +4,15 @@ import { type ComponentPropsWithRef } from 'react'
 import { cn } from '@/shared/lib'
 import { PublicRoutes } from '@/shared/enums'
 import { usePathname } from 'next/navigation'
-import { useAuth } from '@/app/(home)/layout'
+import { useMeQuery } from '@/features/auth/api'
 
 const PUBLIC_ROUTES = Object.values(PublicRoutes) as string[]
 
 export function PageContainer({ className, ...rest }: ComponentPropsWithRef<'main'>) {
    const pathname = usePathname()
-   const { isAuthorized } = useAuth()
+   const { data, isLoading } = useMeQuery()
+   const isAuthorized = !!data && !isLoading
+
    const isPublic = PUBLIC_ROUTES.includes(pathname)
    const isHomePage = pathname === PublicRoutes.main
 


### PR DESCRIPTION
Исправлена в (home)/layout ошибка: "useAuth" is not a valid export - useContext заменен на useMe.

Ошибка экспорта:
<img width="950" height="342" alt="ea6d4bc8-ff96-4cc9-8907-725719d8e1af" src="https://github.com/user-attachments/assets/0d905ded-0864-4c35-8679-ff04ee20c370" />
 