### PR TITLE
YAY-110 Fixed alert for 401 login

### DIFF
--- a/src/shared/store/base-query.ts
+++ b/src/shared/store/base-query.ts
@@ -41,7 +41,11 @@ export const baseQueryWithReAuth: BaseQueryFn<
       const urlParams = new URLSearchParams(window.location.search)
       const isOAuthSuccess = urlParams.get(QUERY_PARAMS.oauthSuccess) === 'true'
 
-      if (!token && !isOAuthSuccess) return result
+      //alert error for 401
+      if (!token && !isOAuthSuccess) {
+         handleError(api, result)
+         return result
+      }
 
       if (!mutex.isLocked()) {
          const release = await mutex.acquire()

--- a/src/shared/utils/handleError.ts
+++ b/src/shared/utils/handleError.ts
@@ -8,6 +8,7 @@ import {
 import { isErrorWithMessage } from '.'
 import { alert } from '@/shared/components/Alert'
 import { isErrorInArray } from '@/shared/utils/typeguards/isErrorInArray'
+import { AuthEndpoints } from '../enums'
 
 export const handleError = (
    api: BaseQueryApi,
@@ -18,7 +19,9 @@ export const handleError = (
 
    //remove the 401 alert for the request me
    const requestUrl = result.meta?.request.url || ''
-   const isMeRequest = requestUrl.includes('/auth/me')
+   //const isMeRequest = requestUrl.includes('/auth/me')
+   const isSilentAuthRequest =
+      requestUrl.includes(AuthEndpoints.me) || requestUrl.includes(AuthEndpoints.logout)
 
    if (result.error) {
       switch (result.error.status) {
@@ -43,8 +46,8 @@ export const handleError = (
                error = JSON.stringify(result.error.data)
             }
 
-            //remove the 401 alert for the request me
-            if (isMeRequest && result.error.status === 401) {
+            //remove the 401 alert for the request me/logout
+            if (isSilentAuthRequest && result.error.status === 401) {
                flag = false
             }
             break


### PR DESCRIPTION
Исправлено: - при неправильном вводе email или password не срабатывает Alert с текстом из респонса на 401 error.

Alert работает, выводится текст из респонса на 401 error для email или password:
<img width="1496" height="836" alt="errorSign" src="https://github.com/user-attachments/assets/cb3281cf-3ff6-4268-86f7-b41be3ffed89" />
